### PR TITLE
Change output files to netCDF4 Classic format

### DIFF
--- a/mppnccombine-fast.c
+++ b/mppnccombine-fast.c
@@ -122,7 +122,7 @@ void init(const char * in_path, const char * out_path, const struct args_t * arg
     // Open both files
     NCERR(nc_open(in_path, NC_NOWRITE, &in_file));
 
-    int out_flags = NC_NETCDF4;
+    int out_flags = NC_NETCDF4 | NC_CLASSIC_MODEL;
     if (!args->force) out_flags |= NC_NOCLOBBER;
     int err = nc_create(out_path, out_flags, &out_file);
     if (err == -35) {


### PR DESCRIPTION
Change output files to netCDF4 Classic format which is backwards API compatible with netCDF3

Fixes https://github.com/coecms/mppnccombine-fast/issues/18