### PR TITLE
Round up for chunk decomposition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/conda
     - source ~/conda/bin/activate
     - conda create --yes -c conda-forge -n mppnccombine-fast-build gcc openmpi 'hdf5>=1.10.2' libnetcdf nomkl
-    - conda create --yes -c conda-forge -n mppnccombine-fast-test openmpi pytest xarray nomkl
+    - conda create --yes -c conda-forge -n mppnccombine-fast-test openmpi pytest xarray nomkl netcdf4
 
 script:
     - make CONDA_BUILD=1 mppnccombine-fast

--- a/mppnccombine-fast.c
+++ b/mppnccombine-fast.c
@@ -131,12 +131,20 @@ void init(const char * in_path, const char * out_path, const struct args_t * arg
         int varid;
 
         NCERR(nc_inq_dim(in_file, d, name, &len));
+        log_message(LOG_DEBUG, "checking variable %s", name);
 
         // Check if the variable with the same name is collated
-        NCERR(nc_inq_varid(in_file, name, &varid));
-        if (is_collated(in_file, varid)) {
-            // If so get the full length
-            get_collated_dim_len(in_file, name, &len);
+        err = nc_inq_varid(in_file, name, &varid);
+        if (err == NC_ENOTVAR) {
+            // No associated variable
+            continue;
+        } else {
+            NCERR(err);
+
+            if (is_collated(in_file, varid)) {
+                // If so get the full length
+                get_collated_dim_len(in_file, name, &len);
+            }
         }
 
         // Create the out dim
@@ -424,7 +432,7 @@ int main(int argc, char ** argv) {
     log_message(LOG_DEBUG, "Cleanup glob");
     globfree(&globs);
     log_message(LOG_DEBUG, "Cleanup win");
-    MPI_Win_free(&current_file_win);
+    //MPI_Win_free(&current_file_win);
 
     log_message(LOG_DEBUG, "MPI_Finalize");
     return MPI_Finalize();

--- a/read_chunked.c
+++ b/read_chunked.c
@@ -364,9 +364,8 @@ void copy_chunked(const char * filename, int async_writer_rank) {
             is_aligned &= in_chunk[d] == out_chunk[d];
             // Start lines up with chunks
             is_aligned &= out_offset[d]%out_chunk[d] == 0;
-            // End lines up with chunks, or is the final chunk
-            is_aligned &= ((out_offset[d] + local_size[d])%out_chunk[d] == 0
-                           || out_offset[d] + local_size[d] == total_size[d]);
+            // End lines up with chunks
+            is_aligned &= ((out_offset[d] + local_size[d])%out_chunk[d] == 0);
         }
 
         if (is_aligned && filters_match) {

--- a/test.py
+++ b/test.py
@@ -25,6 +25,7 @@ import pytest
 import os
 import glob
 import sys
+import numpy.testing
 
 def run_nccopy(options, infiles, outdir):
     try:
@@ -111,6 +112,7 @@ def test_simple(tmpdir):
     c = run_collate([inpath], outpath)
 
     assert (c.a.data == d.a.data).all()
+    numpy.testing.assert_array_equal(c.a.data, d.a.data)
 
 
 def test_split_on_boundary(tmpdir):
@@ -311,3 +313,27 @@ def test_many_files(tmpdir):
     c = run_collate([tmpdir.join('*.nc')], outpath)
 
     assert d.equals(c)
+
+def test_partial_vertical_chunk(tmpdir):
+    inpath = str(tmpdir.join('test.nc'))
+    outpath = tmpdir.join('out.nc')
+    d = xarray.Dataset(
+            {
+                'a': (['z','x'], numpy.zeros((3,1)))
+            },
+            coords = {
+                'x': np.arange(1),
+                'z': np.arange(3),
+            })
+    d.x.attrs['domain_decomposition'] = [1, 1, 1, 1]
+
+    d.to_netcdf(inpath, encoding={
+            'a': {
+                'chunksizes': (2,1),
+                },
+        })
+
+    c = run_collate([inpath], outpath)
+
+    numpy.testing.assert_array_equal(c.a.data, d.a.data)
+


### PR DESCRIPTION
Previously the number of chunks was calculated by dividing the dimension size by the chunk size and rounding down. Round up instead.

Fixes #29 